### PR TITLE
Fixes #2; enables vendor and personal/vanity MIME trees

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.rb]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "rake"
+  # old version of rubocop uses `last_command`; didn't want to upgrade
+  gem "rake", "~> 10.0"
   gem "guard"
   gem "guard-rspec", :require => false
 end

--- a/spec/lib/content_type_spec.rb
+++ b/spec/lib/content_type_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe ContentType do
       its(:subtype)     { should eq "beef" }
       its(:parameters)  { should eq "any" => "thing" }
     end
+
+    context "application/vnd.oasis.opendocument.text" do
+      let(:raw) { "application/vnd.oasis.opendocument.text" }
+
+      its(:type)        { should eq "application" }
+      its(:subtype)     { should eq "vnd.oasis.opendocument.text" }
+    end
+
+    context "vnd.android.cursor.dir/vnd.myexample.whatever" do
+      let(:raw) { "vnd.android.cursor.dir/vnd.myexample.whatever" }
+
+      its(:type)        { should eq "vnd.android.cursor.dir" }
+      its(:subtype)     { should eq "vnd.myexample.whatever" }
+    end
   end
 
   describe "#type" do


### PR DESCRIPTION
Addresses #2.

For future maintainability, this also includes a fix to the `Gemfile` (old Rubocop incompatibility leads to a break with Rake 11+) and an `.editorconfig` to address some Rubocop formatting complaints.

I'm writing a framework that relies upon `content-type`, 'cause it's awesome--a timely review and release would be super appreciated!