### PR TITLE
Dependency updates, Rubocop update, linter fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.rb]
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,16 @@
+AllCops:
+  TargetRubyVersion: 2.2
+  Exclude:
+    - Gemfile
+    - content_type.gemspec
+
 ## Styles ######################################################################
 
 # See: http://erniemiller.org/2014/10/23/in-defense-of-alias/
 Style/Alias:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
 Style/BracesAroundHashParameters:
@@ -16,23 +22,20 @@ Style/BracesAroundHashParameters:
 Style/Documentation:
   Enabled: false
 
-Style/EmptyLineBetweenDefs:
+Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
-
-Style/Encoding:
-  EnforcedStyle: when_needed
 
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Style/IndentHash:
+Layout/IndentHash:
   EnforcedStyle: consistent
 
 # New lambda syntax is as ugly to me as new syntax of Hash.
 Style/Lambda:
   Enabled: false
 
-Style/MultilineOperationIndentation:
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
 # IMHO `%r{foo/bar}` looks way more cleaner than `/foo\/bar/`.
@@ -49,7 +52,10 @@ Style/RegexpLiteral:
 #     conn.hset    :k1, now
 #     conn.hincrby :k2, 123
 #   end
-Style/SingleSpaceBeforeFirstArg:
+Layout/SpaceBeforeFirstArg:
+  Enabled: false
+
+Style/StderrPuts:
   Enabled: false
 
 Style/StringLiterals:
@@ -74,3 +80,7 @@ Style/TrivialAccessors:
 Metrics/MethodLength:
   CountComments: false
   Max: 15
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/lib/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
 group :development do
-  gem "rake"
+  # old version of rubocop uses `last_command`; didn't want to upgrade
+  gem "rake", "~> 10.0"
   gem "guard"
   gem "guard-rspec", :require => false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ end
 
 group :test do
   gem "coveralls"
-  gem "rspec",      "~> 3.1"
+  gem "rspec",      "~> 3.7"
   gem "rspec-its"
-  gem "simplecov",  ">= 0.9"
+  gem "simplecov",  "~> 0.14" # 0.15 interferes with coveralls 0.8.21
   gem "rubocop",    "~> 0.52.0"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source "https://rubygems.org"
 
 group :development do
-  # old version of rubocop uses `last_command`; didn't want to upgrade
-  gem "rake", "~> 10.0"
+  gem "rake", "~> 12.3"
   gem "guard"
   gem "guard-rspec", :require => false
 end
@@ -12,7 +11,7 @@ group :test do
   gem "rspec",      "~> 3.1"
   gem "rspec-its"
   gem "simplecov",  ">= 0.9"
-  gem "rubocop",    "~> 0.28.0"
+  gem "rubocop",    "~> 0.52.0"
 end
 
 group :doc do

--- a/Rakefile
+++ b/Rakefile
@@ -14,4 +14,4 @@ rescue LoadError
   end
 end
 
-task :default => [:spec, :rubocop]
+task :default => %i[spec rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -14,4 +14,6 @@ rescue LoadError
   end
 end
 
-task :default => %i[spec rubocop]
+# rubocop:disable Style/SymbolArray
+task :default => [:spec, :rubocop]
+# rubocop:enable Style/SymbolArray

--- a/content_type.gemspec
+++ b/content_type.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "content_type/version"

--- a/lib/content-type.rb
+++ b/lib/content-type.rb
@@ -1,2 +1,3 @@
-# rubocop: disable FileName
+# rubocop:disable FileName
 require "content_type"
+# rubocop:enable FileName

--- a/lib/content_type.rb
+++ b/lib/content_type.rb
@@ -26,7 +26,7 @@ class ContentType
   end
 
   def to_s
-    (["#{mime_type}"] + parameters.map { |k, v| "#{k}=#{v.to_s.inspect}" })
+    ([mime_type.to_s] + parameters.map { |k, v| "#{k}=#{v.to_s.inspect}" })
       .compact.join("; ")
   end
   alias :to_str :to_s

--- a/lib/content_type/parser.rb
+++ b/lib/content_type/parser.rb
@@ -36,9 +36,7 @@ class ContentType
       str(s).tap { |o| o.instance_variable_set :@str, /#{Regexp.escape s}/i }
     end
 
-    # rubocop:disable LineLength
-    # rubocop:disable Blocks
-    # rubocop:disable BlockAlignment
+    # rubocop:disable Metrics/LineLength
 
     CHAR      = CharList.new { (0..127).to_a.map(&:chr) }
     CTLS      = CharList.new { (0..31).to_a.map(&:chr) << 127.chr }
@@ -75,5 +73,7 @@ class ContentType
     rule(:parameters)     { space.repeat >> str(";") >> space.repeat >> parameter.as(:parameter) }
     rule(:content_type)   { type.as(:type) >> str("/") >> subtype.as(:subtype) >> parameters.repeat }
     root(:content_type)
+
+    # rubocop:enable Metrics/LineLength
   end
 end

--- a/lib/content_type/version.rb
+++ b/lib/content_type/version.rb
@@ -1,3 +1,3 @@
 class ContentType
-  VERSION = "0.0.1"
+  VERSION = "0.0.1".freeze
 end

--- a/spec/lib/content_type_spec.rb
+++ b/spec/lib/content_type_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe ContentType do
       its(:subtype)     { should eq "beef" }
       its(:parameters)  { should eq "any" => "thing" }
     end
+
+    context "application/vnd.oasis.opendocument.text" do
+      let(:raw) { "application/vnd.oasis.opendocument.text" }
+
+      its(:type)        { should eq "application" }
+      its(:subtype)     { should eq "vnd.oasis.opendocument.text" }
+    end
+
+    context "vnd.android.cursor.dir/vnd.myexample.whatever" do
+      let(:raw) { "vnd.android.cursor.dir/vnd.myexample.whatever" }
+
+      its(:type)        { should eq "vnd.android.cursor.dir" }
+      its(:subtype)     { should eq "vnd.myexample.whatever" }
+    end
   end
 
   describe "#type" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 require "simplecov"
 require "coveralls"
 


### PR DESCRIPTION
Follows onto PR #3; as I'm using this in a project I needed to modernize its dependencies a bit. I took a minute to fix its rubocop warnings, too.

I was forced to use `TargetRubyVersion: 2.2` in `.rubocop.yml`; however, I don't believe I broke source compatibility with 1.9.x (not that I think supporting it makes sense).